### PR TITLE
Add single post page with API route

### DIFF
--- a/handlers/post_details_handler.go
+++ b/handlers/post_details_handler.go
@@ -1,0 +1,107 @@
+package handlers
+
+import (
+	"forum/repository"
+	"forum/utils"
+	"net/http"
+	"strings"
+)
+
+type PostDetailsHandler struct {
+	PostRepo     *repository.PostRepository
+	CommentRepo  *repository.CommentRepository
+	ReactionRepo *repository.ReactionRepository
+}
+
+func NewPostDetailsHandler(postRepo *repository.PostRepository, commentRepo *repository.CommentRepository, reactionRepo *repository.ReactionRepository) *PostDetailsHandler {
+	return &PostDetailsHandler{PostRepo: postRepo, CommentRepo: commentRepo, ReactionRepo: reactionRepo}
+}
+
+func (h *PostDetailsHandler) GetPost(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		utils.ErrorResponse(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	id := strings.TrimPrefix(r.URL.Path, "/forum/api/posts/")
+	if id == "" {
+		utils.ErrorResponse(w, "Post ID required", http.StatusBadRequest)
+		return
+	}
+
+	post, err := h.PostRepo.GetPostByIDWithUser(id)
+	if err != nil {
+		utils.ErrorResponse(w, "Failed to load post", http.StatusInternalServerError)
+		return
+	}
+
+	categories, err := h.PostRepo.GetCategoriesByPostID(post.ID)
+	if err != nil {
+		utils.ErrorResponse(w, "Failed to load categories", http.StatusInternalServerError)
+		return
+	}
+	var catInfo []CategoryInfo
+	for _, c := range categories {
+		catInfo = append(catInfo, CategoryInfo{ID: c.ID, Name: c.Name})
+	}
+
+	comments, err := h.CommentRepo.GetCommentsByPostWithUser(post.ID)
+	if err != nil {
+		utils.ErrorResponse(w, "Failed to load comments", http.StatusInternalServerError)
+		return
+	}
+	var commentResp []CommentResponse
+	for _, c := range comments {
+		cr := CommentResponse{
+			ID:        c.ID,
+			UserID:    c.UserID,
+			Username:  c.Username,
+			Content:   c.Content,
+			CreatedAt: c.CreatedAt,
+			Reactions: []ReactionResponse{},
+		}
+		reactions, err := h.ReactionRepo.GetReactionsByCommentWithUser(c.ID)
+		if err != nil {
+			utils.ErrorResponse(w, "Failed to load reactions", http.StatusInternalServerError)
+			return
+		}
+		for _, r := range reactions {
+			cr.Reactions = append(cr.Reactions, ReactionResponse{
+				UserID:       r.UserID,
+				Username:     r.Username,
+				ReactionType: r.ReactionType,
+				CreatedAt:    r.CreatedAt,
+			})
+		}
+		commentResp = append(commentResp, cr)
+	}
+
+	reactions, err := h.ReactionRepo.GetReactionsByPostWithUser(post.ID)
+	if err != nil {
+		utils.ErrorResponse(w, "Failed to load reactions", http.StatusInternalServerError)
+		return
+	}
+	var reactResp []ReactionResponse
+	for _, r := range reactions {
+		reactResp = append(reactResp, ReactionResponse{
+			UserID:       r.UserID,
+			Username:     r.Username,
+			ReactionType: r.ReactionType,
+			CreatedAt:    r.CreatedAt,
+		})
+	}
+
+	response := MyPostResponse{
+		ID:         post.ID,
+		UserID:     post.UserID,
+		Username:   post.Username,
+		Categories: catInfo,
+		Title:      post.Title,
+		Content:    post.Content,
+		CreatedAt:  post.CreatedAt,
+		Comments:   commentResp,
+		Reactions:  reactResp,
+	}
+
+	utils.JSONResponse(w, response, http.StatusOK)
+}

--- a/repository/post_repository.go
+++ b/repository/post_repository.go
@@ -190,3 +190,18 @@ func (r *PostRepository) GetPostsReactedByUser(userID string) ([]models.PostWith
 	}
 	return posts, nil
 }
+
+// GetPostByIDWithUser returns a single post with the author's username
+func (r *PostRepository) GetPostByIDWithUser(postID string) (*models.PostWithUser, error) {
+	row := r.db.QueryRow(`
+                SELECT p.post_id, p.user_id, u.username, p.title, p.content, p.created_at
+                FROM posts p
+                JOIN user u ON p.user_id = u.user_id
+                WHERE p.post_id = ?`, postID)
+
+	var p models.PostWithUser
+	if err := row.Scan(&p.ID, &p.UserID, &p.Username, &p.Title, &p.Content, &p.CreatedAt); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -27,6 +27,7 @@ func SetupRoutes(db *sql.DB) http.Handler {
 	likedPostsHandler := handlers.NewLikedPostsHandler(postRepo, commentRepo, reactionRepo)
 	commentHandler := handlers.NewCommentHandler(commentRepo)
 	reactionHandler := handlers.NewReactionHandler(reactionRepo)
+	postDetailsHandler := handlers.NewPostDetailsHandler(postRepo, commentRepo, reactionRepo)
 	guestHandler := handlers.NewGuestHandler(categoryRepo, postRepo, commentRepo, reactionRepo)
 
 	// Create middleware
@@ -41,6 +42,7 @@ func SetupRoutes(db *sql.DB) http.Handler {
 	// Public routes
 	mux.Handle("/forum/api/categories", corsMiddleware.Handler(http.HandlerFunc(categoryHandler.GetCategories)))
 	mux.Handle("/forum/api/guest", corsMiddleware.Handler(http.HandlerFunc(guestHandler.GetGuestData)))
+	mux.Handle("/forum/api/posts/", corsMiddleware.Handler(http.HandlerFunc(postDetailsHandler.GetPost)))
 	mux.Handle("/forum/api/register", corsMiddleware.Handler(http.HandlerFunc(registerLimiter.Limit(authHandler.Register))))
 	mux.Handle("/forum/api/session/login", corsMiddleware.Handler(http.HandlerFunc(authHandler.Login)))
 	mux.Handle("/forum/api/session/logout", corsMiddleware.Handler(http.HandlerFunc(authHandler.Logout)))

--- a/ui/config.go
+++ b/ui/config.go
@@ -13,4 +13,5 @@ var (
 	CreatePostURI = APIBaseURL + "/posts/create"
 	MyPostsURI    = APIBaseURL + "/user/posts"
 	LikedPostsURI = APIBaseURL + "/user/liked"
+	PostDetailURI = APIBaseURL + "/posts/"
 )

--- a/ui/main.go
+++ b/ui/main.go
@@ -27,6 +27,9 @@ func main() {
 	http.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "./static/templates/user.html")
 	})
+	http.HandleFunc("/post", func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "./static/templates/post.html")
+	})
 	http.HandleFunc("/config", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		config := map[string]string{
@@ -42,6 +45,7 @@ func main() {
 			"CreatePostURI": CreatePostURI,
 			"MyPostsURI":    MyPostsURI,
 			"LikedPostsURI": LikedPostsURI,
+			"PostDetailURI": PostDetailURI,
 		}
 		json.NewEncoder(w).Encode(config)
 	})

--- a/ui/static/js/guest.js
+++ b/ui/static/js/guest.js
@@ -161,7 +161,12 @@ document.addEventListener("DOMContentLoaded", async () => {
           );
         }
 
-        commentsContainer.appendChild(commentElement);
+      commentsContainer.appendChild(commentElement);
+      });
+
+      postContainer.addEventListener("click", (e) => {
+        if (e.target.closest("button")) return;
+        window.location.href = `/post.html?id=${post.id}`;
       });
 
       forumContainer.appendChild(postElement);
@@ -268,7 +273,12 @@ document.addEventListener("DOMContentLoaded", async () => {
           );
         }
 
-        commentsContainer.appendChild(commentElement);
+      commentsContainer.appendChild(commentElement);
+      });
+
+      postContainer.addEventListener("click", (e) => {
+        if (e.target.closest("button")) return;
+        window.location.href = `/post.html?id=${post.id}`;
       });
 
       postsContainer.appendChild(postElement);

--- a/ui/static/js/post.js
+++ b/ui/static/js/post.js
@@ -1,0 +1,133 @@
+import { ConfigManager } from "./user-config-manager.js";
+import { AuthGuard } from "./user-auth-guard.js";
+import { countReactions } from "./user-utils.js";
+
+(async () => {
+  const configManager = new ConfigManager();
+  await configManager.loadConfig();
+  const API_CONFIG = configManager.getConfig();
+  const authGuard = new AuthGuard();
+  const authenticated = await authGuard.checkAuthentication(API_CONFIG);
+  if (!authenticated) return;
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const postId = urlParams.get("id");
+  if (!postId) {
+    document.getElementById("forumContainer").textContent = "Post ID missing";
+    return;
+  }
+
+  async function fetchPost() {
+    const res = await fetch(`${API_CONFIG.APIBaseURL}/posts/${postId}`, {
+      credentials: "include",
+    });
+    if (!res.ok) throw new Error("Failed to load post");
+    return res.json();
+  }
+
+  async function handleReaction(targetId, targetType, reactionType, likeBtn, dislikeBtn) {
+    const res = await fetch(API_CONFIG.ReactionsURI, {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": sessionStorage.getItem("csrf_token"),
+      },
+      body: JSON.stringify({
+        target_id: targetId,
+        target_type: targetType,
+        reaction_type: reactionType,
+      }),
+    });
+    if (!res.ok) return;
+    const updated = await res.json();
+    const { likes, dislikes } = countReactions(updated);
+    likeBtn.querySelector(".like-count").textContent = likes;
+    dislikeBtn.querySelector(".dislike-count").textContent = dislikes;
+  }
+
+  function addCommentInput(postContainer) {
+    const commentBtn = postContainer.querySelector(".comment-btn");
+    commentBtn.addEventListener("click", () => {
+      let box = postContainer.querySelector(".comment-input");
+      if (!box) {
+        box = document.createElement("div");
+        box.classList.add("comment-input");
+        const ta = document.createElement("textarea");
+        ta.placeholder = "Write your comment...";
+        ta.rows = 3;
+        ta.style.width = "100%";
+        const sb = document.createElement("button");
+        sb.textContent = "Submit Comment";
+        sb.classList.add("comment-btn");
+        sb.addEventListener("click", async () => {
+          const content = ta.value.trim();
+          if (!content) return;
+          const res = await fetch(API_CONFIG.CommentsURI, {
+            method: "POST",
+            credentials: "include",
+            headers: {
+              "Content-Type": "application/json",
+              "X-CSRF-Token": sessionStorage.getItem("csrf_token"),
+            },
+            body: JSON.stringify({ post_id: postId, content }),
+          });
+          if (!res.ok) return;
+          ta.value = "";
+          await render();
+        });
+        box.appendChild(ta);
+        box.appendChild(sb);
+        postContainer.appendChild(box);
+      }
+    });
+  }
+
+  async function render() {
+    const data = await fetchPost();
+    const container = document.getElementById("forumContainer");
+    container.innerHTML = "";
+    const postTemplate = document.getElementById("post-template");
+    const commentTemplate = document.getElementById("comment-template");
+
+    const postElement = postTemplate.content.cloneNode(true);
+    postElement.querySelector(
+      ".post-header"
+    ).textContent = `${data.username} posted in ${data.categories.map((c) => c.name).join(", ")}`;
+    postElement.querySelector(".post-title").textContent = data.title;
+    postElement.querySelector(".post-content").textContent = data.content;
+    postElement.querySelector(".post-time").textContent = new Date(data.created_at).toLocaleString();
+
+    const postContainer = postElement.querySelector(".post");
+    const likeBtn = postContainer.querySelector(".like-btn");
+    const dislikeBtn = postContainer.querySelector(".dislike-btn");
+    const { likes, dislikes } = countReactions(data.reactions || []);
+    likeBtn.querySelector(".like-count").textContent = likes;
+    dislikeBtn.querySelector(".dislike-count").textContent = dislikes;
+    likeBtn.addEventListener("click", () => handleReaction(data.id, "post", 1, likeBtn, dislikeBtn));
+    dislikeBtn.addEventListener("click", () => handleReaction(data.id, "post", 2, likeBtn, dislikeBtn));
+
+    const commentsContainer = postElement.querySelector(".post-comments");
+    commentsContainer.innerHTML = "";
+    (data.comments || []).forEach((comment) => {
+      const commentElement = commentTemplate.content.cloneNode(true);
+      const node = commentElement.querySelector(".comment");
+      node.querySelector(".comment-user").textContent = comment.username;
+      node.querySelector(".comment-content").textContent = comment.content;
+      node.querySelector(".comment-time").textContent = new Date(comment.created_at).toLocaleString();
+      const cLike = node.querySelector(".like-btn");
+      const cDis = node.querySelector(".dislike-btn");
+      const counts = countReactions(comment.reactions || []);
+      cLike.querySelector(".like-count").textContent = counts.likes;
+      cDis.querySelector(".dislike-count").textContent = counts.dislikes;
+      cLike.addEventListener("click", () => handleReaction(comment.id, "comment", 1, cLike, cDis));
+      cDis.addEventListener("click", () => handleReaction(comment.id, "comment", 2, cLike, cDis));
+      commentsContainer.appendChild(commentElement);
+    });
+
+    addCommentInput(postContainer);
+    container.appendChild(postElement);
+  }
+
+  render();
+})();

--- a/ui/static/js/user-post-renderer.js
+++ b/ui/static/js/user-post-renderer.js
@@ -78,6 +78,11 @@ class PostRenderer {
 
     this.commentHandler.addCommentInput(postContainer, post, refreshFn);
 
+    postContainer.addEventListener("click", (e) => {
+      if (e.target.closest("button")) return;
+      window.location.href = `/post.html?id=${post.id}`;
+    });
+
     container.appendChild(postElement);
   }
 }

--- a/ui/static/templates/post.html
+++ b/ui/static/templates/post.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Post Details</title>
+    <link rel="stylesheet" href="/static/css/user.css" />
+  </head>
+  <body>
+    <nav class="navbar">
+      <a class="navbar-brand" href="/user">Forum</a>
+      <ul class="navbar-links">
+        <li><a href="#" id="logout-link">Logout</a></li>
+      </ul>
+    </nav>
+
+    <div class="forum-content" id="forumContainer"></div>
+
+    <template id="post-template">
+      <div class="post">
+        <h3 class="post-header"></h3>
+        <div class="post-title"></div>
+        <p class="post-content"></p>
+        <time class="post-time"></time>
+        <div class="post-reactions">
+          <button class="like-btn">👍 <span class="like-count">0</span></button>
+          <button class="dislike-btn">👎 <span class="dislike-count">0</span></button>
+          <button class="comment-btn">Add Comment</button>
+        </div>
+        <div class="post-comments"></div>
+      </div>
+    </template>
+
+    <template id="comment-template">
+      <div class="comment">
+        <strong class="comment-user"></strong>
+        <span class="comment-content"></span>
+        <time class="comment-time"></time>
+        <div class="comment-reactions">
+          <button class="like-btn">👍 <span class="like-count">0</span></button>
+          <button class="dislike-btn">👎 <span class="dislike-count">0</span></button>
+        </div>
+      </div>
+    </template>
+
+    <script src="/static/js/post.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- create `PostDetailsHandler` with new repo method `GetPostByIDWithUser`
- expose `GET /forum/api/posts/{id}` and serve new `/post` page
- add `PostDetailURI` to config
- update user and guest UIs so posts open a detailed page
- implement `post.js` to display a post, its likes/dislikes and comments

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_685263d4b0448324916835e52cfbfad2