### PR TITLE
Enable post title navigation

### DIFF
--- a/ui/static/css/guest.css
+++ b/ui/static/css/guest.css
@@ -201,6 +201,13 @@
     margin: 0 0 0.5em;
     font-size: 1.2em;
   }
+
+  .post-title {
+    color: var(--color-primary);
+    font-size: 1.5em;
+    font-weight: bold;
+    cursor: pointer;
+  }
   
   .post p {
     color: #ccc;

--- a/ui/static/css/user.css
+++ b/ui/static/css/user.css
@@ -217,6 +217,7 @@
     color: var(--color-primary);
     font-size: 2em;
     font-weight: bolder;
+    cursor: pointer;
   }
   
   .comment {

--- a/ui/static/js/guest.js
+++ b/ui/static/js/guest.js
@@ -111,6 +111,12 @@ document.addEventListener("DOMContentLoaded", async () => {
       }
 
 
+      const titleEl = postElement.querySelector(".post-title");
+      titleEl.addEventListener("click", (e) => {
+        e.stopPropagation();
+        window.location.href = `/post.html?id=${post.id}`;
+      });
+
       postContainer.addEventListener("click", (e) => {
         if (e.target.closest("button")) return;
         window.location.href = `/post.html?id=${post.id}`;
@@ -169,6 +175,12 @@ document.addEventListener("DOMContentLoaded", async () => {
         );
       }
 
+
+      const titleEl = postElement.querySelector(".post-title");
+      titleEl.addEventListener("click", (e) => {
+        e.stopPropagation();
+        window.location.href = `/post.html?id=${post.id}`;
+      });
 
       postContainer.addEventListener("click", (e) => {
         if (e.target.closest("button")) return;

--- a/ui/static/js/user-post-renderer.js
+++ b/ui/static/js/user-post-renderer.js
@@ -36,6 +36,12 @@ class PostRenderer {
 
 
 
+    const titleEl = postElement.querySelector(".post-title");
+    titleEl.addEventListener("click", (e) => {
+      e.stopPropagation();
+      window.location.href = `/post.html?id=${post.id}`;
+    });
+
     postContainer.addEventListener("click", (e) => {
       if (e.target.closest("button")) return;
       window.location.href = `/post.html?id=${post.id}`;


### PR DESCRIPTION
## Summary
- make post titles look clickable
- navigate to the post details page when clicking titles

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_68526fbdda748324b23f9cc375c064fe