### PR TITLE
Add guest view for individual posts

### DIFF
--- a/ui/main.go
+++ b/ui/main.go
@@ -30,6 +30,9 @@ func main() {
 	http.HandleFunc("/post", func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "./static/templates/post.html")
 	})
+	http.HandleFunc("/guest-post", func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "./static/templates/post_guest.html")
+	})
 	http.HandleFunc("/config", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		config := map[string]string{

--- a/ui/static/js/guest-post.js
+++ b/ui/static/js/guest-post.js
@@ -1,0 +1,76 @@
+import { ConfigManager } from "./user-config-manager.js";
+import { countReactions } from "./user-utils.js";
+
+(async () => {
+  const configManager = new ConfigManager();
+  await configManager.loadConfig();
+  const API_CONFIG = configManager.getConfig();
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const postId = urlParams.get("id");
+  if (!postId) {
+    document.getElementById("forumContainer").textContent = "Post ID missing";
+    return;
+  }
+
+  async function fetchPost() {
+    const res = await fetch(`${API_CONFIG.APIBaseURL}/posts/${postId}`);
+    if (!res.ok) throw new Error("Failed to load post");
+    return res.json();
+  }
+
+  async function render() {
+    const data = await fetchPost();
+    const container = document.getElementById("forumContainer");
+    container.innerHTML = "";
+    const postTemplate = document.getElementById("post-template");
+    const commentTemplate = document.getElementById("comment-template");
+
+    const postElement = postTemplate.content.cloneNode(true);
+    postElement.querySelector(
+      ".post-header"
+    ).textContent = `${data.username} posted in ${data.categories
+      .map((c) => c.name)
+      .join(", ")}`;
+    postElement.querySelector(".post-title").textContent = data.title;
+    postElement.querySelector(".post-content").textContent = data.content;
+    postElement.querySelector(".post-time").textContent = new Date(
+      data.created_at
+    ).toLocaleString();
+
+    const postContainer = postElement.querySelector(".post");
+    const likeBtn = postContainer.querySelector(".like-btn");
+    const dislikeBtn = postContainer.querySelector(".dislike-btn");
+    const commentBtn = postContainer.querySelector(".comment-btn");
+    likeBtn.disabled = true;
+    dislikeBtn.disabled = true;
+    commentBtn.style.display = "none";
+    const { likes, dislikes } = countReactions(data.reactions || []);
+    likeBtn.querySelector(".like-count").textContent = likes;
+    dislikeBtn.querySelector(".dislike-count").textContent = dislikes;
+
+    const commentsContainer = postElement.querySelector(".post-comments");
+    commentsContainer.innerHTML = "";
+    (data.comments || []).forEach((comment) => {
+      const commentElement = commentTemplate.content.cloneNode(true);
+      const node = commentElement.querySelector(".comment");
+      node.querySelector(".comment-user").textContent = comment.username;
+      node.querySelector(".comment-content").textContent = comment.content;
+      node.querySelector(".comment-time").textContent = new Date(
+        comment.created_at
+      ).toLocaleString();
+      const cLike = node.querySelector(".like-btn");
+      const cDis = node.querySelector(".dislike-btn");
+      const counts = countReactions(comment.reactions || []);
+      cLike.querySelector(".like-count").textContent = counts.likes;
+      cDis.querySelector(".dislike-count").textContent = counts.dislikes;
+      cLike.disabled = true;
+      cDis.disabled = true;
+      commentsContainer.appendChild(commentElement);
+    });
+
+    container.appendChild(postElement);
+  }
+
+  render();
+})();

--- a/ui/static/js/guest.js
+++ b/ui/static/js/guest.js
@@ -114,12 +114,12 @@ document.addEventListener("DOMContentLoaded", async () => {
       const titleEl = postElement.querySelector(".post-title");
       titleEl.addEventListener("click", (e) => {
         e.stopPropagation();
-        window.location.href = `/post.html?id=${post.id}`;
+        window.location.href = `/guest-post?id=${post.id}`;
       });
 
       postContainer.addEventListener("click", (e) => {
         if (e.target.closest("button")) return;
-        window.location.href = `/post.html?id=${post.id}`;
+        window.location.href = `/guest-post?id=${post.id}`;
       });
 
       forumContainer.appendChild(postElement);
@@ -179,12 +179,12 @@ document.addEventListener("DOMContentLoaded", async () => {
       const titleEl = postElement.querySelector(".post-title");
       titleEl.addEventListener("click", (e) => {
         e.stopPropagation();
-        window.location.href = `/post.html?id=${post.id}`;
+        window.location.href = `/guest-post?id=${post.id}`;
       });
 
       postContainer.addEventListener("click", (e) => {
         if (e.target.closest("button")) return;
-        window.location.href = `/post.html?id=${post.id}`;
+        window.location.href = `/guest-post?id=${post.id}`;
       });
 
       postsContainer.appendChild(postElement);

--- a/ui/static/templates/post_guest.html
+++ b/ui/static/templates/post_guest.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Post Details</title>
+    <link rel="stylesheet" href="/static/css/user.css" />
+  </head>
+  <body>
+    <nav class="navbar">
+      <a class="navbar-brand" href="/">Forum</a>
+      <ul class="navbar-links">
+        <li><a href="/login">Login</a></li>
+        <li><a href="/register">Register</a></li>
+      </ul>
+    </nav>
+
+    <div class="forum-content" id="forumContainer"></div>
+
+    <template id="post-template">
+      <div class="post">
+        <h3 class="post-header"></h3>
+        <div class="post-title"></div>
+        <p class="post-content"></p>
+        <time class="post-time"></time>
+        <div class="post-reactions">
+          <button class="like-btn">👍 <span class="like-count">0</span></button>
+          <button class="dislike-btn">👎 <span class="dislike-count">0</span></button>
+          <button class="comment-btn">Add Comment</button>
+        </div>
+        <div class="post-comments"></div>
+      </div>
+    </template>
+
+    <template id="comment-template">
+      <div class="comment">
+        <strong class="comment-user"></strong>
+        <span class="comment-content"></span>
+        <time class="comment-time"></time>
+        <div class="comment-reactions">
+          <button class="like-btn">👍 <span class="like-count">0</span></button>
+          <button class="dislike-btn">👎 <span class="dislike-count">0</span></button>
+        </div>
+      </div>
+    </template>
+
+    <script src="/static/js/guest-post.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- allow guests to open posts in read‑only mode
- create `guest-post.js` and `post_guest.html`
- add `/guest-post` route in UI server
- update guest page links to use the new route

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68527d23074c832495a7eea4953960a0