### PR TITLE
Fix post route links

### DIFF
--- a/ui/static/js/user-post-renderer.js
+++ b/ui/static/js/user-post-renderer.js
@@ -39,12 +39,12 @@ class PostRenderer {
     const titleEl = postElement.querySelector(".post-title");
     titleEl.addEventListener("click", (e) => {
       e.stopPropagation();
-      window.location.href = `/post.html?id=${post.id}`;
+      window.location.href = `/post?id=${post.id}`;
     });
 
     postContainer.addEventListener("click", (e) => {
       if (e.target.closest("button")) return;
-      window.location.href = `/post.html?id=${post.id}`;
+      window.location.href = `/post?id=${post.id}`;
     });
 
     container.appendChild(postElement);


### PR DESCRIPTION
## Summary
- adjust user feed links to use `/post` route

## Testing
- `curl -I http://localhost:8085/user -b ../cookies.txt`
- `curl -I "http://localhost:8085/post?id=a5d609f3-da5c-481f-9f7a-9a7ecd4f8a72" -b ../cookies.txt`
- `curl -v http://localhost:8084/forum/api/session/verify -b ../cookies.txt`


------
https://chatgpt.com/codex/tasks/task_e_685288d78fbc832489248224dd8f2140